### PR TITLE
Fix namespace to comply with PSR-0

### DIFF
--- a/source/Mocka/Invokables/Invokable/OriginalMethodWrapperInterface.php
+++ b/source/Mocka/Invokables/Invokable/OriginalMethodWrapperInterface.php
@@ -1,5 +1,5 @@
 <?php
 
-namespace Mocka\Invokable\Invokable;
+namespace Mocka\Invokables\Invokable;
 
 interface OriginalMethodWrapperInterface {};


### PR DESCRIPTION
Fixing typo in namespace so `composer install` does not complain about it.

>Class Mocka\Invokable\Invokable\OriginalMethodWrapperInterface located in ./vendor/tomaszdurka/mocka/source/Mocka/Invokables/Invokable/OriginalMethodWrapperInterface.php does not comply with psr-0 autoloading standard. Skipping.